### PR TITLE
examples use include bytes rather than file system operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "chrono",
+ "clap",
  "nexrad-model",
  "serde",
  "thiserror",

--- a/nexrad-decode/Cargo.toml
+++ b/nexrad-decode/Cargo.toml
@@ -14,4 +14,5 @@ bincode = { workspace = true }
 serde = { workspace = true }
 chrono = { workspace = true }
 nexrad-model = { path = "../nexrad-model" }
+clap = { workspace = true }
 uom = { workspace = true, optional = true  }

--- a/nexrad-decode/examples/digital_radar_data_message.rs
+++ b/nexrad-decode/examples/digital_radar_data_message.rs
@@ -8,11 +8,11 @@
 //!
 
 use nexrad_decode::messages::digital_radar_data::decode_digital_radar_data;
-use std::fs;
+
+const DIGITAL_RADAR_DATA_MESSAGE: &[u8] = include_bytes!("data/digital_radar_data_message");
 
 fn main() {
-    let file = fs::read("examples/data/digital_radar_data_message").expect("file exists");
-    let mut reader = std::io::Cursor::new(file.as_slice());
+    let mut reader = std::io::Cursor::new(DIGITAL_RADAR_DATA_MESSAGE);
 
     let message = decode_digital_radar_data(&mut reader).unwrap();
     println!("Decoded digital radar data message: {:?}", message);

--- a/nexrad-decode/examples/message_header.rs
+++ b/nexrad-decode/examples/message_header.rs
@@ -7,12 +7,12 @@
 //!
 
 use nexrad_decode::messages::decode_message_header;
-use std::fs;
+
+const MESSAGE_HEADER: &[u8] = include_bytes!("data/message_header");
 
 fn main() {
-    let file = fs::read("examples/data/message_header").expect("file exists");
-    let mut reader = std::io::Cursor::new(file.as_slice());
+    let mut reader = std::io::Cursor::new(MESSAGE_HEADER);
 
-    let message_header = decode_message_header(&mut reader).unwrap();
-    println!("Decoded message header: {:?}", message_header);
+    let decoded_msg_header = decode_message_header(&mut reader).unwrap();
+    println!("Decoded message header: {:?}", decoded_msg_header);
 }


### PR DESCRIPTION
turn runtime error into compile time error